### PR TITLE
fix date field in podatki.json and frontend rendering

### DIFF
--- a/data/podatki.json
+++ b/data/podatki.json
@@ -1,1 +1,2 @@
-{"povabljeniPrebivalci": "3000", "sprejetaPovabila": "663", "odvzetihVzorcev": "19", "dateHour": "2020-04-20T22:09:20.410790+00:00"}
+{"povabljeniPrebivalci": "3000", "sprejetaPovabila": "839", "odvzetihVzorcev": "61", "dateHour": "2020-04-21T09:39:43.864537+00:00"}
+

--- a/data/podatki.json
+++ b/data/podatki.json
@@ -1,6 +1,1 @@
-{
-  "povabljeniPrebivalci" : "3000",
-  "sprejetaPovabila" : "631",
-  "odvzetihVzorcev": "16",
-  "dateHour" : "20. 4. 2020 ob 20.46"
-}
+{"povabljeniPrebivalci": "3000", "sprejetaPovabila": "663", "odvzetihVzorcev": "19", "dateHour": "2020-04-20T22:09:20.410790+00:00"}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -23,7 +23,17 @@
         </div>
         <div class="row mt-5">
           <div class="col-lg-3 col-md-3 col-sm-4 col-6 text-right" ><h6><small>Podatki ažurirani:</small></h6></div>
-          <div class="col-lg-9 col-md-9 col-sm-8 col-6" style="padding-left: 0"><h6>{{ .Site.Data.podatki.dateHour }}</h6></div>
+          <div class="col-lg-9 col-md-9 col-sm-8 col-6" style="padding-left: 0">
+            <h6>
+              <script>
+                let d = new Date("{{.Site.Data.podatki.dateHour}}");
+                document.write(`${d.getDate()}. ${d.getMonth() + 1}. ${d.getFullYear()} ob ${d.getHours()}.${("0" + d.getMinutes()).slice(-2)}`);
+              </script>
+              <noscript>
+                {{ dateFormat "2. 1. 2006 ob 15:04" .Site.Data.podatki.dateHour }}
+              </noscript>
+            </h6>
+          </div>
         </div>
       </div>
     </div>

--- a/layouts/partials/dateReformat.html
+++ b/layouts/partials/dateReformat.html
@@ -1,6 +1,0 @@
-{{- $fix := replace (substr . 0 10 ) "-" "." -}}
-{{ substr $fix 8 2 }}.{{ substr $fix 5 2 }}.{{ substr $fix 0 4}}
-
-<!--
-//TODO Add DateFormating from podatki.json to webview
--->


### PR DESCRIPTION
This should fix our recent change in `podatki.json` where we changed the `dateHour` field into a ISO 8601 format UTC string (i.e. python3 datetime.isoformat()).

The frontend should render now the date & time in local time. 